### PR TITLE
Non-local Redis + Redis with auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ configure(allprojects) { project ->
   }
 
   dependencies {
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.2'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.2'
     compile("io.vertx:vertx-core:${vertxVersion}")
     compile("io.vertx:vertx-rx-java:${vertxVersion}")
     compile("io.vertx:vertx-hazelcast:${vertxVersion}")

--- a/kue-core/src/main/generated/io/vertx/blueprint/kue/service/rxjava/JobService.java
+++ b/kue-core/src/main/generated/io/vertx/blueprint/kue/service/rxjava/JobService.java
@@ -53,17 +53,17 @@ public class JobService {
     return delegate;
   }
 
-  /**
-   * Factory method for creating a {@link io.vertx.blueprint.kue.service.rxjava.JobService} instance.
-   *
-   * @param vertx  Vertx instance
-   * @param config configuration
-   * @return the new {@link io.vertx.blueprint.kue.service.rxjava.JobService} instance
-   */
-  public static JobService create(Vertx vertx, JsonObject config) {
-    JobService ret = JobService.newInstance(io.vertx.blueprint.kue.service.JobService.create(vertx.getDelegate(), config));
-    return ret;
-  }
+//  /**
+//   * Factory method for creating a {@link io.vertx.blueprint.kue.service.rxjava.JobService} instance.
+//   *
+//   * @param vertx  Vertx instance
+//   * @param config configuration
+//   * @return the new {@link io.vertx.blueprint.kue.service.rxjava.JobService} instance
+//   */
+//  public static JobService create(Vertx vertx, JsonObject config) {
+//    JobService ret = JobService.newInstance(io.vertx.blueprint.kue.service.JobService.create(vertx.getDelegate(), config));
+//    return ret;
+//  }
 
   /**
    * Factory method for creating a {@link io.vertx.blueprint.kue.service.rxjava.JobService} service proxy.

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
@@ -39,7 +39,7 @@ public class Kue {
     this.config = config;
     this.jobService = JobService.createProxy(vertx, EB_JOB_SERVICE_ADDRESS);
     this.client = RedisHelper.client(vertx, config);
-    Job.setVertx(vertx, RedisHelper.client(vertx, config)); // init static vertx instance inner job
+    Job.setVertx(vertx, RedisHelper.client(vertx, config), config); // init static vertx instance inner job
   }
 
   /**

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
@@ -104,7 +104,10 @@ public class Kue {
 
   private void processInternal(String type, Handler<Job> handler, boolean isWorker) {
     KueWorker worker = new KueWorker(type, handler, this);
-    vertx.deployVerticle(worker, new DeploymentOptions().setWorker(isWorker), r0 -> {
+    DeploymentOptions options = new DeploymentOptions();
+    options.setWorker(isWorker);
+    options.setConfig(vertx.getOrCreateContext().config());
+    vertx.deployVerticle(worker, options, r0 -> {
       if (r0.succeeded()) {
         this.on("job_complete", msg -> {
           long dur = new Job(((JsonObject) msg.body()).getJsonObject("job")).getDuration();

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
@@ -106,7 +106,7 @@ public class Kue {
     KueWorker worker = new KueWorker(type, handler, this);
     DeploymentOptions options = new DeploymentOptions();
     options.setWorker(isWorker);
-    options.setConfig(vertx.getOrCreateContext().config());
+    options.setConfig(config);
     vertx.deployVerticle(worker, options, r0 -> {
       if (r0.succeeded()) {
         this.on("job_complete", msg -> {

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
@@ -42,6 +42,14 @@ public class Kue {
     Job.setVertx(vertx, RedisHelper.client(vertx, config), config); // init static vertx instance inner job
   }
 
+  public Kue(Vertx vertx, JsonObject config, RedisClient redisClient) {
+    this.vertx = vertx;
+    this.config = config;
+    this.jobService = JobService.createProxy(vertx, EB_JOB_SERVICE_ADDRESS);
+    this.client = redisClient;
+    Job.setVertx(vertx, redisClient, config); // init static vertx instance inner job
+  }
+
   /**
    * Generate handler address with certain job on event bus.
    * <p>Format: vertx.kue.handler.job.{handlerType}.{addressId}.{jobType}</p>

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/Kue.java
@@ -111,7 +111,7 @@ public class Kue {
   }
 
   private void processInternal(String type, Handler<Job> handler, boolean isWorker) {
-    KueWorker worker = new KueWorker(type, handler, this);
+    KueWorker worker = new KueWorker(type, handler, this, client);
     DeploymentOptions options = new DeploymentOptions();
     options.setWorker(isWorker);
     options.setConfig(config);

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -34,11 +34,13 @@ public class Job {
 
   private static Vertx vertx;
   private static RedisClient client;
+  private static JsonObject config;
   private static EventBus eventBus;
 
-  public static void setVertx(Vertx v, RedisClient redisClient) {
+  public static void setVertx(Vertx v, RedisClient redisClient, JsonObject config) {
     vertx = v;
     client = redisClient;
+    config = redisConfig;
     eventBus = vertx.eventBus();
   }
 
@@ -161,7 +163,7 @@ public class Job {
    */
   public Future<Job> state(JobState newState) {
     Future<Job> future = Future.future();
-    RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
+    RedisClient client = RedisHelper.client(vertx, config); // use a new client to keep transaction
     JobState oldState = this.state;
     logger.debug("Job::state(from: " + oldState + ", to:" + newState.name() + ")");
     client.transaction().multi(r0 -> {

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -161,7 +161,7 @@ public class Job {
    */
   public Future<Job> state(JobState newState) {
     Future<Job> future = Future.future();
-    RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
+    //RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
     JobState oldState = this.state;
     logger.debug("Job::state(from: " + oldState + ", to:" + newState.name() + ")");
     client.transaction().multi(r0 -> {
@@ -194,27 +194,27 @@ public class Job {
 
         client.transaction().exec(r -> {
           if (r.succeeded()) {
-            client.close(c -> {
-              if (c.failed()) {
-                c.cause().printStackTrace();
-              }
-            });
+//             client.close(c -> {
+//               if (c.failed()) {
+//                 c.cause().printStackTrace();
+//               }
+//             });
             future.complete(this);
           } else {
-            client.close(c -> {
-              if (c.failed()) {
-                c.cause().printStackTrace();
-              }
-            });
+//             client.close(c -> {
+//               if (c.failed()) {
+//                 c.cause().printStackTrace();
+//               }
+//             });
             future.fail(r.cause());
           }
         });
       } else {
-        client.close(c -> {
-          if (c.failed()) {
-            c.cause().printStackTrace();
-          }
-        });
+//         client.close(c -> {
+//           if (c.failed()) {
+//             c.cause().printStackTrace();
+//           }
+//         });
         future.fail(r0.cause());
       }
     });

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -161,7 +161,7 @@ public class Job {
    */
   public Future<Job> state(JobState newState) {
     Future<Job> future = Future.future();
-    //RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
+    RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
     JobState oldState = this.state;
     logger.debug("Job::state(from: " + oldState + ", to:" + newState.name() + ")");
     client.transaction().multi(r0 -> {
@@ -194,28 +194,28 @@ public class Job {
 
         client.transaction().exec(r -> {
           if (r.succeeded()) {
-//             client.close(c -> {
-//               if (c.failed()) {
-//                 c.cause().printStackTrace();
-//               }
-//             });
-            future.complete(this);
+             client.close(c -> {
+               if (c.failed()) {
+                 future.fail(c.cause());
+               }
+               future.complete(this);
+             });
           } else {
-//             client.close(c -> {
-//               if (c.failed()) {
-//                 c.cause().printStackTrace();
-//               }
-//             });
-            future.fail(r.cause());
+             client.close(c -> {
+               if (c.failed()) {
+                 future.fail(c.cause());
+               }
+               future.fail(r.cause());
+             });
           }
         });
       } else {
-//         client.close(c -> {
-//           if (c.failed()) {
-//             c.cause().printStackTrace();
-//           }
-//         });
-        future.fail(r0.cause());
+         client.close(c -> {
+           if (c.failed()) {
+             future.fail(c.cause());
+           }
+           future.fail(r0.cause());
+         });
       }
     });
 

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -161,7 +161,7 @@ public class Job {
    */
   public Future<Job> state(JobState newState) {
     RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
-    state(client, newState);
+    return state(client, newState);
   }
 
   public Future<Job> state(RedisClient client, JobState newState) {
@@ -418,7 +418,7 @@ public class Job {
    * Save the job to the backend.
    */
   public Future<Job> save() {
-    save(client);
+    return save(client);
   }
 
   public Future<Job> save(RedisClient client) {
@@ -465,7 +465,7 @@ public class Job {
    * Update the job.
    */
   Future<Job> update() {
-    update(client);
+    return update(client);
   }
 
   Future<Job> update(RedisClient client) {

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -194,12 +194,27 @@ public class Job {
 
         client.transaction().exec(r -> {
           if (r.succeeded()) {
+            client.close(c -> {
+              if (c.failed()) {
+                c.cause().printStackTrace();
+              }
+            });
             future.complete(this);
           } else {
+            client.close(c -> {
+              if (c.failed()) {
+                c.cause().printStackTrace();
+              }
+            });
             future.fail(r.cause());
           }
         });
       } else {
+        client.close(c -> {
+          if (c.failed()) {
+            c.cause().printStackTrace();
+          }
+        });
         future.fail(r0.cause());
       }
     });

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -480,7 +480,7 @@ public class Job {
     // TODO: add search functionality (full-index engine, for Chinese language this is difficult)
 
     return future.compose(r ->
-      this.state(this.state));
+      this.state(client, this.state));
   }
 
   /**

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -161,7 +161,7 @@ public class Job {
    */
   public Future<Job> state(JobState newState) {
     Future<Job> future = Future.future();
-    RedisClient client = RedisHelper.client(vertx, new JsonObject()); // use a new client to keep transaction
+    RedisClient client = RedisHelper.client(vertx, vertx.getOrCreateContext().config()); // use a new client to keep transaction
     JobState oldState = this.state;
     logger.debug("Job::state(from: " + oldState + ", to:" + newState.name() + ")");
     client.transaction().multi(r0 -> {

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/Job.java
@@ -37,7 +37,7 @@ public class Job {
   private static JsonObject config;
   private static EventBus eventBus;
 
-  public static void setVertx(Vertx v, RedisClient redisClient, JsonObject config) {
+  public static void setVertx(Vertx v, RedisClient redisClient, JsonObject redisConfig) {
     vertx = v;
     client = redisClient;
     config = redisConfig;

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
@@ -45,8 +45,7 @@ public class KueVerticle extends AbstractVerticle {
         this.jobService = JobService.create(vertx, config, redisClient);
     }
 
-    //todo: impl ping
-    redisClient.get("ping", pr -> { // test connection
+    redisClient.ping(pr -> { // test connection
       if (pr.succeeded()) {
         logger.info("Kue Verticle is running...");
 

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
@@ -31,9 +31,9 @@ public class KueVerticle extends AbstractVerticle {
   public void start(Future<Void> future) throws Exception {
     this.config = config();
     if (this.redisClient == null) {
-        this.jobService = JobService.create(vertx, config);
-        // create redis client
-        this.redisClient = RedisHelper.client(vertx, config);
+      // create redis client
+      this.redisClient = RedisHelper.client(vertx, config);
+      this.jobService = JobService.create(vertx, config, RedisHelper.client(vertx, config));
     } else {
         this.jobService = JobService.create(vertx, config, redisClient);
     }

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
@@ -25,7 +25,14 @@ public class KueVerticle extends AbstractVerticle {
 
   private JsonObject config;
   private JobService jobService;
-  public static RedisClient redisClient;
+  private RedisClient redisClient;
+
+  public KueVerticle() {
+  }
+
+  public KueVerticle(RedisClient redisClient) {
+      this.redisClient = redisClient;
+  }
 
   @Override
   public void start(Future<Void> future) throws Exception {

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
@@ -25,14 +25,28 @@ public class KueVerticle extends AbstractVerticle {
 
   private JsonObject config;
   private JobService jobService;
+  private RedisClient redisClient;
+
+  KueVerticle() {
+  }
+
+  KueVerticle(RedisClient redisClient) {
+    this.redisClient = redisClient;
+  }
 
   @Override
   public void start(Future<Void> future) throws Exception {
     this.config = config();
-    this.jobService = JobService.create(vertx, config);
-    // create redis client
-    RedisClient redisClient = RedisHelper.client(vertx, config);
-    redisClient.ping(pr -> { // test connection
+    if (this.redisClient == null) {
+        this.jobService = JobService.create(vertx, config);
+        // create redis client
+        this.redisClient = RedisHelper.client(vertx, config);
+    } else {
+        this.jobService = JobService.create(vertx, config, redisClient);
+    }
+
+    //todo: impl ping
+    redisClient.get("ping", pr -> { // test connection
       if (pr.succeeded()) {
         logger.info("Kue Verticle is running...");
 

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueVerticle.java
@@ -25,14 +25,7 @@ public class KueVerticle extends AbstractVerticle {
 
   private JsonObject config;
   private JobService jobService;
-  private RedisClient redisClient;
-
-  KueVerticle() {
-  }
-
-  KueVerticle(RedisClient redisClient) {
-    this.redisClient = redisClient;
-  }
+  public static RedisClient redisClient;
 
   @Override
   public void start(Future<Void> future) throws Exception {

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueWorker.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/queue/KueWorker.java
@@ -37,16 +37,16 @@ public class KueWorker extends AbstractVerticle {
   private MessageConsumer doneConsumer; // Preserve for unregister the consumer.
   private MessageConsumer doneFailConsumer;
 
-  public KueWorker(String type, Handler<Job> jobHandler, Kue kue) {
+  public KueWorker(String type, Handler<Job> jobHandler, Kue kue, RedisClient redisClient) {
     this.type = type;
     this.jobHandler = jobHandler;
     this.kue = kue;
+    this.client = redisClient;
   }
 
   @Override
   public void start() throws Exception {
     this.eventBus = vertx.eventBus();
-    this.client = RedisHelper.client(vertx, config());
 
     prepareAndStart();
   }

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/service/JobService.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/service/JobService.java
@@ -24,17 +24,17 @@ import java.util.List;
 @ProxyGen
 @VertxGen
 public interface JobService {
-
-  /**
-   * Factory method for creating a {@link JobService} instance.
-   *
-   * @param vertx  Vertx instance
-   * @param config configuration
-   * @return the new {@link JobService} instance
-   */
-  static JobService create(Vertx vertx, JsonObject config) {
-    return new JobServiceImpl(vertx, config);
-  }
+//
+//  /**
+//   * Factory method for creating a {@link JobService} instance.
+//   *
+//   * @param vertx  Vertx instance
+//   * @param config configuration
+//   * @return the new {@link JobService} instance
+//   */
+//  static JobService create(Vertx vertx, JsonObject config) {
+//    return new JobServiceImpl(vertx, config);
+//  }
 
   static JobService create(Vertx vertx, JsonObject config, RedisClient redisClient) {
     return new JobServiceImpl(vertx, config, redisClient);

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/service/JobService.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/service/JobService.java
@@ -11,6 +11,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.redis.RedisClient;
 import io.vertx.serviceproxy.ProxyHelper;
 
 import java.util.List;
@@ -33,6 +34,10 @@ public interface JobService {
    */
   static JobService create(Vertx vertx, JsonObject config) {
     return new JobServiceImpl(vertx, config);
+  }
+
+  static JobService create(Vertx vertx, JsonObject config, RedisClient redisClient) {
+    return new JobServiceImpl(vertx, config, redisClient);
   }
 
   /**

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/service/impl/JobServiceImpl.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/service/impl/JobServiceImpl.java
@@ -38,6 +38,13 @@ public final class JobServiceImpl implements JobService {
     Job.setVertx(vertx, RedisHelper.client(vertx, config), config); // init static vertx instance inner job
   }
 
+  public JobServiceImpl(Vertx vertx, JsonObject config, RedisClient redisClient) {
+    this.vertx = vertx;
+    this.config = config;
+    this.client = redisClient;
+    Job.setVertx(vertx, client, config); // init static vertx instance inner job
+  }
+
   @Override
   public JobService getJob(long id, Handler<AsyncResult<Job>> handler) {
     String zid = RedisHelper.createFIFO(id);

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/service/impl/JobServiceImpl.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/service/impl/JobServiceImpl.java
@@ -35,7 +35,7 @@ public final class JobServiceImpl implements JobService {
     this.vertx = vertx;
     this.config = config;
     this.client = RedisClient.create(vertx, RedisHelper.options(config));
-    Job.setVertx(vertx, RedisHelper.client(vertx, config)); // init static vertx instance inner job
+    Job.setVertx(vertx, RedisHelper.client(vertx, config), config); // init static vertx instance inner job
   }
 
   @Override

--- a/kue-core/src/main/java/io/vertx/blueprint/kue/util/RedisHelper.java
+++ b/kue-core/src/main/java/io/vertx/blueprint/kue/util/RedisHelper.java
@@ -38,7 +38,8 @@ public final class RedisHelper {
   public static RedisOptions options(JsonObject config) {
     return new RedisOptions()
       .setHost(config.getString("redis.host", "127.0.0.1"))
-      .setPort(config.getInteger("redis.port", 6379));
+      .setPort(config.getInteger("redis.port", 6379))
+      .setAuth(config.getString("redis.auth", null));
   }
 
   /**


### PR DESCRIPTION
This fixes a few issues I had with vertx-kue. Other than these issues everything seems to work fairly well.

First, the config isn't passed to all the verticles that are deployed. This caused the deployed verticles to revert back to using the default config which will try to connect to localhost. This works fine until you have a Redis host which isn't local.

Second, the ```Job.state(JobState newState)``` method starts a new Redis client but doesn't close it when it's finished. Causes an eventual max Redis connections error.

Finally, there was no place to input Redis auth. Added that.